### PR TITLE
Add local version of the calculator test that does not use a proxy

### DIFF
--- a/java/.gitignore
+++ b/java/.gitignore
@@ -1,1 +1,5 @@
 /build/
+/.gradle/
+.classpath
+.project
+.settings

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -7,6 +7,7 @@ plugins {
 group = 'com.mabl.example'
 ext {
   baseVersion = '1.0.0'
+  seleniumVersion = '3.141.59'
 }
 
 sourceCompatibility = 8
@@ -18,7 +19,8 @@ repositories {
 
 dependencies {
   testCompile group: 'junit', name: 'junit', version: '4.+'
-  testCompile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
+  testCompile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: seleniumVersion
+  testCompile group: 'org.seleniumhq.selenium', name: 'selenium-chrome-driver', version: seleniumVersion
 }
 
 test {

--- a/java/src/test/java/com/mabl/example/selenium/SeleniumTestWithProxySupport.java
+++ b/java/src/test/java/com/mabl/example/selenium/SeleniumTestWithProxySupport.java
@@ -1,6 +1,17 @@
 package com.mabl.example.selenium;
 
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import com.google.common.base.Preconditions;
+import okhttp3.ConnectionPool;
+import org.junit.After;
+import org.junit.Before;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.remote.HttpCommandExecutor;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.http.HttpClient;
+import org.openqa.selenium.remote.internal.OkHttpClient;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -8,18 +19,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Optional;
 
-import org.junit.After;
-import org.junit.Before;
-import org.openqa.selenium.Capabilities;
-import org.openqa.selenium.MutableCapabilities;
-import org.openqa.selenium.remote.HttpCommandExecutor;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.openqa.selenium.remote.http.HttpClient;
-import org.openqa.selenium.remote.internal.OkHttpClient;
-
-import com.google.common.base.Preconditions;
-
-import okhttp3.ConnectionPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Base class for all Selenium tests that initializes/configures the web driver
@@ -28,16 +28,30 @@ import okhttp3.ConnectionPool;
 abstract public class SeleniumTestWithProxySupport {
     private static final String WEB_DRIVER_URL = "http://localhost:9515";
     private static final String MABL_CLI_PROXY = "localhost:8889";
-    protected RemoteWebDriver driver;
+    protected WebDriver driver;
+    private final boolean useProxy;
+
+    protected SeleniumTestWithProxySupport() {
+        this(true);
+    }
+
+    protected SeleniumTestWithProxySupport(final boolean useProxy) {
+        this.useProxy = useProxy;
+    }
 
     @Before
     public void setUp() {
-        driver = createRemoteDriver(WEB_DRIVER_URL, MABL_CLI_PROXY);
+        if (useProxy) {
+            driver = createRemoteDriver(WEB_DRIVER_URL, MABL_CLI_PROXY);
+        }
+        else {
+            driver = new ChromeDriver();
+        }
     }
 
     @After
     public void tearDown() {
-        Optional.ofNullable(driver).ifPresent(RemoteWebDriver::quit);
+        Optional.ofNullable(driver).ifPresent(WebDriver::quit);
     }
 
     private static RemoteWebDriver createRemoteDriver(final String url, final String proxy) {

--- a/java/src/test/java/com/mabl/example/selenium/UseCalculatorLocalTest.java
+++ b/java/src/test/java/com/mabl/example/selenium/UseCalculatorLocalTest.java
@@ -3,11 +3,17 @@ package com.mabl.example.selenium;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
+import org.openqa.selenium.JavascriptExecutor;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-public class UseCalculatorTest extends SeleniumTestWithProxySupport {
+public class UseCalculatorLocalTest extends SeleniumTestWithProxySupport {
+
+    public UseCalculatorLocalTest() {
+        super(false);
+    }
+
     @Test
     public void useCalculator() throws Exception {
         driver.get("http://juliemr.github.io/protractor-demo/");
@@ -16,7 +22,7 @@ public class UseCalculatorTest extends SeleniumTestWithProxySupport {
         driver.findElement(By.cssSelector("[ng-model=first]")).sendKeys("1");
         driver.findElement(By.cssSelector("[ng-model=second]")).click();
         driver.findElement(By.cssSelector("[ng-model=second]")).sendKeys("2");
-        driver.findElement(By.id("gobutton")).click();
+        ((JavascriptExecutor) driver).executeScript("arguments[0].click();", driver.findElement(By.id("gobutton")));
         Thread.sleep(3000L);
         assertThat(driver.findElement(By.cssSelector(".ng-binding:nth-child(5)")).getText(), is("3"));
     }


### PR DESCRIPTION
Updates `SeleniumTestWithProxySupport` to make the proxy optional.  Adds a `UseCalculatorLocalTest` which does _not_ use the proxy; this is intended to be used with the Java Selenium Agent import method instead.